### PR TITLE
Remove toPosInt(Array::length)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var clear    = require('es5-ext/array/#/clear')
-  , toPosInt = require('es5-ext/number/to-pos-integer')
   , assign   = require('es5-ext/object/assign')
   , callable = require('es5-ext/object/valid-callable')
   , value    = require('es5-ext/object/valid-value')
@@ -30,14 +29,13 @@ module.exports = Iterator = function (list, context) {
 defineProperties(Iterator.prototype, assign({
 	constructor: d(Iterator),
 	_next: d(function () {
-		var i, l;
+		var i;
 		if (!this.__list__) return;
 		if (this.__redo__) {
 			i = this.__redo__.shift();
 			if (i !== undefined) return i;
 		}
-		l = toPosInt(this.__list__.length);
-		if (this.__nextIndex__ < l) return this.__nextIndex__++;
+		if (this.__nextIndex__ < this.__list__.length) return this.__nextIndex__++;
 		this._unBind();
 	}),
 	next: d(function () { return this._createResult(this._next()); }),


### PR DESCRIPTION
Array length always matches `toPosInt` requirements (integer number >= 0) and removing conversion speeds up iterators up to 80% (from 37,660 ops/sec to 68,312 ops/sec  for arrays on my machine).
